### PR TITLE
fix bytes->string error

### DIFF
--- a/r6rs-lib/r6rs/private/readtable.rkt
+++ b/r6rs-lib/r6rs/private/readtable.rkt
@@ -475,10 +475,9 @@
                                  16)])
                          (unless (or (<= 0 v #xD7FF)
                                      (<= #xE000 v #x10FFFF))
-                           (let ([str (bytes->string/utf-8 thing)])
-                             (raise-read-error
-                              (format "out of range escape: `\\x~a;'" (cadr m))
-                              src line col pos (and pos (string-length str)))))
+                           (raise-read-error
+                            (format "out of range escape: `\\x~a;'" (caddr m))
+                            src line col pos (and pos (string-length thing))))
                          (string->bytes/utf-8 (string (integer->char v))))
                        (loop (cadddr m))))
                 t)))))]

--- a/r6rs-test/tests/r6rs/exceptions.sls
+++ b/r6rs-test/tests/r6rs/exceptions.sls
@@ -86,6 +86,14 @@
       (test v '(out in out in)))
       
 
+     (test/output
+       (guard (con
+               ((violation? con)
+                (display (condition-message con))
+                'violation))
+              (read (open-string-input-port "\\xDDDD;")))
+       'violation
+       "out of range escape: `\\xDDDD;'")
       
     ;;
     ))


### PR DESCRIPTION
`thing` is defined as a string on [L446](https://github.com/racket/r6rs/blob/ebf0d54e228d3f2e5b8e4e375a84043168ece071/r6rs-lib/r6rs/private/readtable.rkt#L446), so calling `(bytes->string/utf-8 thing)` on [L478](https://github.com/racket/r6rs/pull/1/files#diff-d1307ad5e3cd4dfca6a37a191ca2b54eL478) would raise a contract error.

Though I don't have a test case that proves it.