### PR TITLE
Add .travis.yml [WIP?]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: c
+
+env:
+- PATH=~/racket/bin:$PATH
+- VARIANT=cs PATH=~/racket/bin:$PATH
+
+before_install:
+- if [ $VARIANT = "cs" ]; then curl -L -o installer.sh http://www.cs.utah.edu/plt/snapshots/current/installers/racket-current-x86_64-linux-cs-xenial.sh; else curl -L -o installer.sh http://www.cs.utah.edu/plt/snapshots/current/installers/racket-current-x86_64-linux-precise.sh; fi
+- sh installer.sh --in-place --dest ~/racket/
+
+install:
+- raco pkg install --auto -i --no-setup --skip-installed r6rs-test
+- racket -l- pkg/dirs-catalog --link --check-metadata pkgs-catalog .
+- echo file://`pwd`/pkgs-catalog/ > catalog-config.txt
+- raco pkg config catalogs >> catalog-config.txt
+- raco pkg config --set catalogs `cat catalog-config.txt`
+- raco pkg update -i --auto --no-setup r6rs-test/
+- raco setup --pkgs r6rs-test
+- ls $HOME/.racket/download-cache
+- racket -v
+
+script:
+- racket -l tests/r6rs/run.sps
+


### PR DESCRIPTION
Add the .travis.ylm file to run the tests in the classic and the cs version of racket.

The racket version [raises 3 error](https://travis-ci.org/gus-massa/r6rs/jobs/569565692) (as expected). I'd like to modify the test file to set the error level to 1, but modify the test file to mark them as known/expected errors or something?

The racketcs version [raises only 1 error](https://travis-ci.org/gus-massa/r6rs/jobs/569565694). There is a disagreement about `string-titlecase` with numbers in Racket and R6RS/ChezSheme. I'm not sure it is should be clasified as a bug in _RacketCS_ or as a bug in the _r6rs_ package.
  