### PR TITLE
fix symbol->string to return immutable strings (R6RS §5.10)

### DIFF
--- a/r6rs-lib/rnrs/base-6.rkt
+++ b/r6rs-lib/rnrs/base-6.rkt
@@ -11,6 +11,8 @@
          (for-syntax r6rs/private/reconstruct)
          (prefix-in r5rs: r5rs)
          (only-in r6rs/private/readtable rx:number)
+         (only-in racket/symbol
+                  [symbol->immutable-string r6rs:symbol->string])
          scheme/bool)
 
 (provide 
@@ -129,7 +131,7 @@
 
  ;; 11.10
  symbol? (rename-out [r6rs:symbol=? symbol=?])
- string->symbol symbol->string
+ string->symbol (rename-out [r6rs:symbol->string symbol->string])
  
  ;; 11.11
  char? char=? char<? char>? char<=? char>=?


### PR DESCRIPTION
The report says that:

> the strings returned by `symbol->string` … are immutable objects …
> An attempt to store a new value into a location referred to by an
> immutable object should raise an exception with condition type
> `&assertion`.